### PR TITLE
frameでタイトルなし、noneを選ぶと少しずれる対応

### DIFF
--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -59,6 +59,9 @@ div.frame-public-lang-outer {
 	padding-left: 0px;
 	padding-right: 0px;
 }
+.panel-none > .panel-body {
+	padding-top: 0;
+}
 .panel.panel-none {
 	box-shadow: none;
 }


### PR DESCRIPTION
https://github.com/NetCommons3/NetCommons3/issues/1045

CSSのみの修正なんで、すぐマージしちゃいますね。